### PR TITLE
Improve setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,43 @@
 
 ## 📦 Installation
 
+### Environment Setup
+
+1. Install **Python 3.10** or newer.
+2. Create and activate a virtual environment:
+
+```bash
+python -m venv venv
+source venv/bin/activate  # On Windows use `venv\Scripts\activate`
+```
+
+3. Install all dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+### Download the YOLO model
+
+The backend expects a file called `yolo11n.pt` in the `backend/` directory.
+If it is missing, download the YOLOv8n model from the
+[Ultralytics releases page](https://github.com/ultralytics/assets/releases),
+rename it to `yolo11n.pt` and place it inside `backend/`.
+
+### Starting the backend
+
+Run the FastAPI server from the repository root:
+
+```bash
+uvicorn app.main:app --reload --app-dir backend
+```
+
+The API will be available at `http://127.0.0.1:8000`.
+
+### Accessing the frontend
+
+Open `frontend/index.html` in your browser. The page uploads images to the
+`/match` endpoint of the running backend and displays the results.
 
 ## 🧪 Example
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,14 @@
+fastapi
+uvicorn[standard]
+python-multipart
+numpy
+opencv-python
+Pillow
+faiss-cpu
+torch
+clip-anytorch
+ultralytics
+selenium
+webdriver-manager
+playwright
+rich


### PR DESCRIPTION
## Summary
- add environment setup steps in README
- provide instructions for running backend and accessing frontend
- add requirements.txt with Python dependencies

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415ec4afdc83248dcb451fa93facd6